### PR TITLE
Landing page audit fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,6 +42,32 @@
 }
 
 /* ═══════════════════════════════════════════
+   CHARITY BANNER
+   ═══════════════════════════════════════════ */
+
+.charity-banner {
+    background: linear-gradient(90deg, #E8F6FA 0%, #d4f0e0 50%, #E8F6FA 100%);
+    padding: 0.75rem 1rem;
+    text-align: center;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #2c7a4e;
+    border-bottom: 1px solid #a8e6cf;
+}
+
+.charity-icon {
+    margin-right: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    .charity-banner {
+        background: linear-gradient(90deg, #1a3d2e 0%, #0d3320 50%, #1a3d2e 100%);
+        color: #90ee90;
+        border-bottom: 1px solid #2d5a3f;
+    }
+}
+
+/* ═══════════════════════════════════════════
    BASE
    ═══════════════════════════════════════════ */
 
@@ -277,6 +303,56 @@ h2 { font-size: 1.6rem; }
 .app-store-icon:hover {
     filter: drop-shadow(0 0 8px rgba(var(--retro-glow-rgb), 0.6)) drop-shadow(0 0 16px rgba(var(--retro-glow-rgb), 0.3));
     transform: translateY(-2px) scale(1.02);
+}
+
+.app-store-icon-large {
+    height: 60px;
+}
+
+/* CTA Button */
+.cta-button {
+    display: inline-block;
+    background: var(--retro-primary);
+    color: #ffffff !important;
+    padding: 1rem 2.5rem;
+    border-radius: var(--retro-radius-lg);
+    font-size: 1.2rem;
+    font-weight: 700;
+    text-decoration: none;
+    margin: 1rem 0;
+    transition: all 0.3s ease;
+}
+
+.cta-button:hover {
+    text-shadow: 0 0 4px rgba(255, 255, 255, 0.5);
+    box-shadow: 0 0 15px rgba(var(--retro-glow-rgb), 0.5), 0 0 30px rgba(var(--retro-glow-rgb), 0.3);
+    transform: translateY(-2px);
+    opacity: 1;
+}
+
+/* Screenshot */
+.screenshot-container {
+    margin-top: 2rem;
+    text-align: center;
+}
+
+.screenshot-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--retro-primary);
+    margin-bottom: 0.5rem;
+}
+
+.app-screenshot {
+    max-height: 400px;
+    max-width: 100%;
+    border-radius: var(--retro-radius-md);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.hero-subtitle {
+    font-size: 1.1rem;
+    max-width: 600px;
 }
 
 /* Logo */

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Hey Bible - Search, Save & Share Bible Verses</title>
-    <meta name="description" content="Hey Bible is a free app for searching Bible verses, saving your favorites, adding notes, and creating beautiful shareable images of scripture. Available on iOS and Android." />
+    <title>Hey Bible - Turn Scripture Into Shareable Art</title>
+    <meta name="description" content="Create beautiful, shareable images of Bible verses. Search scripture, save favorites, add notes. Free on iOS and Android." />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="canonical" href="https://heybible.org" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -19,8 +19,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="./img/favicons/favicon-16x16.png" />
     <link rel="manifest" href="./img/favicons/site.webmanifest" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Hey Bible - Search, Save & Share Bible Verses" />
-    <meta property="og:description" content="A free app for searching Bible verses, saving your favorites, adding notes, and creating beautiful shareable images of scripture." />
+    <meta property="og:title" content="Hey Bible - Turn Scripture Into Shareable Art" />
+    <meta property="og:description" content="Create beautiful, shareable images of Bible verses. Search scripture, save favorites, add notes." />
     <meta property="og:image" content="https://heybible.org/img/og-image.png" />
     <meta property="og:image:width" content="1280" />
     <meta property="og:image:height" content="720" />
@@ -28,15 +28,15 @@
     <meta property="og:site_name" content="Hey Bible" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@heybibleapp" />
-    <meta name="twitter:title" content="Hey Bible - Search, Save & Share Bible Verses" />
-    <meta name="twitter:description" content="A free app for searching Bible verses, saving your favorites, adding notes, and creating beautiful shareable images of scripture." />
+    <meta name="twitter:title" content="Hey Bible - Turn Scripture Into Shareable Art" />
+    <meta name="twitter:description" content="Create beautiful, shareable images of Bible verses. Search scripture, save favorites, add notes." />
     <meta name="twitter:image" content="https://heybible.org/img/og-image.png" />
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Hey Bible",
-      "description": "A free app for searching Bible verses, saving your favorites, adding notes, and creating beautiful shareable images of scripture.",
+      "description": "Create beautiful, shareable images of Bible verses. Search scripture, save favorites, add notes.",
       "url": "https://heybible.org",
       "applicationCategory": "LifestyleApplication",
       "operatingSystem": "iOS, Android",
@@ -58,6 +58,11 @@
     </script>
   </head>
   <body>
+    <!-- Charity Banner -->
+    <div class="charity-banner">
+      <span class="charity-icon">❤️</span>
+      <span>Portion of proceeds support Bible distribution to underserved communities</span>
+    </div>
     <header class="main-header">
       <nav class="header-nav">
         <div class="header-left">
@@ -69,25 +74,31 @@
       </nav>
     </header>
     <div class="content">
-      <h1>Download Hey Bible</h1>
+      <h1>Turn Scripture Into Shareable Art</h1>
       <a href="https://heybible.app">
         <img src="./img/logo-small.png" alt="Hey Bible app logo" />
       </a>
-      <p>
+      <p class="hero-subtitle">
         Search the Bible, save your favorite verses, add personal notes, and
-        create beautiful, shareable images of scripture. Free on iOS and Android.
+        create beautiful, shareable images of scripture.
       </p>
+      <a href="https://apps.apple.com/us/app/hey-bible/id6474075530" class="cta-button" target="_blank">Get It Free</a>
       <div class="app-store-container">
         <a
           href="https://apps.apple.com/us/app/hey-bible/id6474075530"
           target="_blank"
-          ><img class="app-store-icon" src="./img/app-store.svg" alt="Download on the App Store"
+          ><img class="app-store-icon app-store-icon-large" src="./img/app-store.svg" alt="Download on the App Store"
         /></a>
         <a
           href="https://play.google.com/store/apps/details?id=com.workingdevshero.heybible"
           target="_blank"
-          ><img class="app-store-icon" src="./img/play-store.svg" alt="Get it on Google Play"
+          ><img class="app-store-icon app-store-icon-large" src="./img/play-store.svg" alt="Get it on Google Play"
         /></a>
+      </div>
+      <!-- App Screenshot -->
+      <div class="screenshot-container">
+        <p class="screenshot-label">Create beautiful verse images in seconds</p>
+        <img src="./img/app-screenshot.png" alt="Hey Bible app screenshot showing a shareable verse image" class="app-screenshot" />
       </div>
     </div>
     <footer class="main-footer">
@@ -101,7 +112,7 @@
           <a href="./terms">Terms</a>
         </div>
         <a href="https://workingdevshero.com" target="_blank"
-          >&copy; Working Dev's Hero LLC</a
+          >Built with ❤️ by Working Dev's Hero</a
         >
       </nav>
     </footer>


### PR DESCRIPTION
## Summary
Addresses landing page audit findings from WOR-8.

## Changes
- **Add charity banner** — Shows 'Portion of proceeds support Bible distribution' at top of page
- **Rewrite headline** — 'Turn Scripture Into Shareable Art' emphasizes unique value prop
- **Add primary CTA** — 'Get It Free' button above app store links
- **Enlarge app store buttons** — 40px -> 60px for better visibility
- **Add screenshot section** — Placeholder for app screenshot showing shareable verse feature
- **Update footer** — 'Built with �u2764ufe0f by Working Dev's Hero' (more human)
- **Update OG/meta tags** — Consistent with new headline

## Issues Fixed
- Fixes #2 (Add charity/donation messaging)
- Fixes #3 (Rewrite headline)
- Fixes #4 (Enlarge app store buttons)
- Fixes #5 (Add app screenshots)

## Screenshots
N/A — changes are straightforward HTML/CSS updates

## Testing
- [ ] Verify charity banner renders correctly
- [ ] Verify headline change on desktop and mobile
- [ ] Verify CTA button is prominent
- [ ] Verify app store buttons are larger
- [ ] Verify screenshot section displays correctly

## Note
The screenshot () needs to be added separately. This PR includes the container and styling for it.