### PR TITLE
feat: move Podcast link before Blog in nav

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,8 +2,8 @@
 const links = [
   { href: '/about', label: 'About', mobileOnly: false },
   { href: '/features', label: 'Features', mobileOnly: false, hideOnMobile: true },
-  { href: '/blog', label: 'Blog', mobileOnly: false, hideOnMobile: true },
   { href: 'https://podcast.heybible.org', label: 'Podcast', external: true, mobileOnly: false },
+  { href: '/blog', label: 'Blog', mobileOnly: false, hideOnMobile: true },
   { href: '/privacy', label: 'Privacy', mobileOnly: false },
   { href: 'https://app.youform.com/forms/o1pfzrgp', label: 'Support', external: true, mobileOnly: false },
   { href: '/terms', label: 'Terms', mobileOnly: false },

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,8 +6,8 @@ const pathname = Astro.url.pathname;
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/features', label: 'Features' },
-  { href: '/blog', label: 'Blog' },
   { href: 'https://podcast.heybible.org', label: 'Podcast', external: true },
+  { href: '/blog', label: 'Blog' },
 ];
 ---
 


### PR DESCRIPTION
Reorders the Podcast navigation link to appear before Blog in both header and footer.